### PR TITLE
Emulate checksum check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Unlike the real file checks, which run antivirus scans and perform real checksum
 calculations, the fake checker generates fake results based on just the original
 filename.
 
-It currently only runs a fake virus scan, but will be updated to support checksum and
-file format ID checks.
+It currently only runs a fake virus scan and checksum, but will be updated to
+support file format ID checks.
 
 ### Configure local Keycloak
 
@@ -75,8 +75,9 @@ Or run the `FakeBackendChecker` object from IntelliJ.
 
 Fake file checks generate their results based on the filenames
 
-| Filename pattern | Examples                   | Antivirus result       |
-| ---------------- | -------------------------- | ---------------------- |
-| *                | example.txt, stuff.doc     | Success (empty string) |
-| eicar*           | eicar, eicar123.exe        | `SUSP_Just_EICAR`      |
-| test-virus*      | test-virus, test-virus.txt | `test_virus`           |
+| Filename pattern | Examples                                     | Antivirus result       | Checksum result                                       |
+| ---------------- | -------------------------------------------- | ---------------------- | ----------------------------------------------------- |
+| *                | example.txt, stuff.doc                       | Success (empty string) | `fake-checksum`                                       |
+| eicar*           | eicar, eicar123.exe                          | `SUSP_Just_EICAR`      | `fake-checksum`                                       |
+| test-virus*      | test-virus, test-virus.txt                   | `test_virus`           | `fake-checksum`                                       |
+| test-checksum-*  | test-checksum-abcde, test-checksum-abcde.doc | Success (empty string) | `abcde` (or whatever was appended to `test-checksum-` |

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
@@ -24,7 +24,7 @@ object FakeBackendChecker extends App {
   private val tokenService = new TokenService(config)
 
   private val antivirusChecker = new AntivirusCheck(tokenService, getDocumentClient, antivirusClient)
-  private val checksumCheck = new ChecksumCheck(tokenService, addMetadataClient)
+  private val checksumCheck = new ChecksumCheck(tokenService, getDocumentClient, addMetadataClient)
 
   private val parentDirectory = Paths.get(config.getString("files.s3UploadDirectory"))
 

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
@@ -7,6 +7,7 @@ import graphql.codegen.AddAntivirusMetadata.AddAntivirusMetadata
 import graphql.codegen.AddFileMetadata.addFileMetadata
 import graphql.codegen.GetOriginalPath.getOriginalPath
 import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.FileService
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.{AntivirusCheck, ChecksumCheck}
 
@@ -23,8 +24,10 @@ object FakeBackendChecker extends App {
 
   private val tokenService = new TokenService(config)
 
-  private val antivirusChecker = new AntivirusCheck(tokenService, getDocumentClient, antivirusClient)
-  private val checksumCheck = new ChecksumCheck(tokenService, getDocumentClient, addMetadataClient)
+  private val fileService = new FileService(getDocumentClient, antivirusClient, addMetadataClient)
+
+  private val antivirusChecker = new AntivirusCheck(tokenService, fileService)
+  private val checksumCheck = new ChecksumCheck(tokenService, fileService)
 
   private val parentDirectory = Paths.get(config.getString("files.s3UploadDirectory"))
 

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
@@ -24,6 +24,9 @@ object FakeBackendChecker extends App {
 
   private val parentDirectory = Paths.get(config.getString("files.s3UploadDirectory"))
 
-  private val fileWatcher = new FileWatcher(parentDirectory, antivirusChecker)
+  private val fileWatcher = new FileWatcher(
+    parentDirectory,
+    Seq(antivirusChecker)
+  )
   fileWatcher.startWatching
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FakeBackendChecker.scala
@@ -4,10 +4,11 @@ import java.nio.file._
 
 import com.typesafe.config.ConfigFactory
 import graphql.codegen.AddAntivirusMetadata.AddAntivirusMetadata
+import graphql.codegen.AddFileMetadata.addFileMetadata
 import graphql.codegen.GetOriginalPath.getOriginalPath
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
-import uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.AntivirusCheck
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.{AntivirusCheck, ChecksumCheck}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -18,15 +19,18 @@ object FakeBackendChecker extends App {
   private val apiUrl = config.getString("api.baseUrl")
   private val getDocumentClient = new GraphQLClient[getOriginalPath.Data, getOriginalPath.Variables](apiUrl)
   private val antivirusClient = new GraphQLClient[AddAntivirusMetadata.Data, AddAntivirusMetadata.Variables](apiUrl)
+  private val addMetadataClient = new GraphQLClient[addFileMetadata.Data, addFileMetadata.Variables](apiUrl)
 
   private val tokenService = new TokenService(config)
+
   private val antivirusChecker = new AntivirusCheck(tokenService, getDocumentClient, antivirusClient)
+  private val checksumCheck = new ChecksumCheck(tokenService, addMetadataClient)
 
   private val parentDirectory = Paths.get(config.getString("files.s3UploadDirectory"))
 
   private val fileWatcher = new FileWatcher(
     parentDirectory,
-    Seq(antivirusChecker)
+    Seq(antivirusChecker, checksumCheck)
   )
   fileWatcher.startWatching
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FileWatcher.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/FileWatcher.scala
@@ -10,7 +10,7 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters._
 
-class FileWatcher(parentDirectory: Path, fileCheck: FileCheck)(implicit executionContext: ExecutionContext) {
+class FileWatcher(parentDirectory: Path, fileChecks: Seq[FileCheck])(implicit executionContext: ExecutionContext) {
 
   private val watcher: WatchService = FileSystems.getDefault.newWatchService
   private val initialPaths: Map[WatchKey, Path] = registerAll(parentDirectory)
@@ -54,7 +54,7 @@ class FileWatcher(parentDirectory: Path, fileCheck: FileCheck)(implicit executio
         checkFilesInDirectory(fullPath)
         currentPaths ++ newPaths
       } else {
-        fileCheck.checkPath(fullPath)
+        fileChecks.foreach(_.checkPath(fullPath))
         currentPaths
       }
     }).toMap
@@ -67,7 +67,7 @@ class FileWatcher(parentDirectory: Path, fileCheck: FileCheck)(implicit executio
   def checkFilesInDirectory(directory: Path): Unit = {
     Files.walkFileTree(directory, new SimpleFileVisitor[Path] {
       override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-        fileCheck.checkPath(file)
+        fileChecks.foreach(_.checkPath(file))
 
         FileVisitResult.CONTINUE
       }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/LocalFilePaths.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/LocalFilePaths.scala
@@ -1,0 +1,23 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks
+
+import java.nio.file.Path
+import java.util.UUID
+
+import scala.util.{Failure, Try}
+
+object LocalFilePaths {
+
+  private val UuidLength = 36
+
+  def extractFileId(path: Path): Try[UUID] = {
+    val fileName = path.getFileName.toString
+    if (fileName.length < UuidLength) {
+      return Failure(new IllegalArgumentException(s"Path '$path' is too short to contain a valid UUID"))
+    }
+
+    // S3Ninja does not store S3 folders as filesystem folders. Instead it puts underscores between the folder
+    // name and the filename, so we have to extract the last 36 digits of the filename to get the filename
+    // that would have been saved to S3.
+    Try(UUID.fromString(path.getFileName.toString.takeRight(UuidLength)))
+  }
+}

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/api/FileService.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/api/FileService.scala
@@ -1,0 +1,62 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.api
+
+import java.nio.file.{Path, Paths}
+import java.time.Instant
+import java.util.UUID
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import graphql.codegen.AddAntivirusMetadata.AddAntivirusMetadata
+import graphql.codegen.AddFileMetadata.addFileMetadata
+import graphql.codegen.GetOriginalPath.getOriginalPath
+import graphql.codegen.types.{AddAntivirusMetadataInput, AddFileMetadataInput}
+import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.GraphQl.sendGraphQlRequest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FileService(
+                   getDocumentClient: GraphQLClient[getOriginalPath.Data, getOriginalPath.Variables],
+                   antivirusClient: GraphQLClient[AddAntivirusMetadata.Data, AddAntivirusMetadata.Variables],
+                   addMetadataClient: GraphQLClient[addFileMetadata.Data, addFileMetadata.Variables]
+                 ) {
+
+  def originalFileName(fileId: UUID, token: BearerAccessToken)(implicit executionContext: ExecutionContext): Future[Path] = {
+    val queryVariables = getOriginalPath.Variables(fileId)
+
+    sendGraphQlRequest(getDocumentClient, token, queryVariables, getOriginalPath.document).map(result => {
+      Paths.get(result.getClientFileMetadata.originalPath.get).getFileName
+    })
+  }
+
+  def saveAntivirusResult(
+                           metadata: AntivirusMetadata,
+                           fileId: UUID,
+                           token: BearerAccessToken
+                         )(implicit executionContext: ExecutionContext): Future[AddAntivirusMetadata.Data] = {
+    val mutationInput = AddAntivirusMetadataInput(
+      fileId,
+      Some(metadata.software),
+      Some(metadata.result),
+      Some(metadata.version),
+      Some(metadata.version),
+      Some(metadata.result),
+      Instant.now().toEpochMilli
+    )
+    val mutationVariables = AddAntivirusMetadata.Variables(mutationInput)
+
+    sendGraphQlRequest(antivirusClient, token, mutationVariables, AddAntivirusMetadata.document)
+  }
+
+  def saveChecksum(
+                    checksum: String,
+                    fileId: UUID,
+                    token: BearerAccessToken
+                  )(implicit executionContext: ExecutionContext): Future[addFileMetadata.Data] = {
+    val addMetadataInput = AddFileMetadataInput("SHA256ServerSideChecksum", fileId, checksum)
+    val mutationVariables = addFileMetadata.Variables(addMetadataInput)
+
+    sendGraphQlRequest(addMetadataClient, token, mutationVariables, addFileMetadata.document)
+  }
+}
+
+case class AntivirusMetadata(software: String, result: String, version: String)

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/api/GraphQl.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/api/GraphQl.scala
@@ -1,0 +1,23 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.api
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import sangria.ast.Document
+import uk.gov.nationalarchives.tdr.GraphQLClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object GraphQl {
+  def sendGraphQlRequest[Data, Variables](
+                                           client: GraphQLClient[Data, Variables],
+                                           token: BearerAccessToken,
+                                           queryVariables: Variables,
+                                           graphQlDocument: Document
+                                         )(implicit executionContext: ExecutionContext): Future[Data] = {
+    client.getResult(token, graphQlDocument, Some(queryVariables)).map(data => {
+      data.data match {
+        case Some(metadata) => metadata
+        case None => throw new RuntimeException(s"Error in GraphQL response: ${data.errors}")
+      }
+    })
+  }
+}

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/AntivirusCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/AntivirusCheck.scala
@@ -1,63 +1,26 @@
 package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
 
-import java.nio.file.{Path, Paths}
-import java.time.Instant
 import java.util.UUID
 
-import graphql.codegen.AddAntivirusMetadata.AddAntivirusMetadata
-import graphql.codegen.GetOriginalPath.getOriginalPath
-import graphql.codegen.types.AddAntivirusMetadataInput
-import uk.gov.nationalarchives.tdr.GraphQLClient
-import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.GraphQl.sendGraphQlRequest
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.FileService
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata.FakeAntivirusMetadata
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class AntivirusCheck(
-                        tokenService: TokenService,
-                        getDocumentClient: GraphQLClient[getOriginalPath.Data, getOriginalPath.Variables],
-                        antivirusClient: GraphQLClient[AddAntivirusMetadata.Data, AddAntivirusMetadata.Variables]
-                      )(implicit val executionContext: ExecutionContext) extends FileCheck {
+                      tokenService: TokenService,
+                      fileService: FileService
+                    )(implicit val executionContext: ExecutionContext) extends FileCheck {
 
-  private val eicarPattern = "(eicar).*".r
-  private val virusPattern = "(test-virus).*".r
+  override def name: String = "antivirus"
 
-  override def checkName: String = "antivirus"
-
-  override def checkFileId(fileId: UUID): Future[Any] = {
-    tokenService.token.flatMap(token => {
-      val queryVariables = getOriginalPath.Variables(fileId)
-
-      sendGraphQlRequest(getDocumentClient, token, queryVariables, getOriginalPath.document).map(result => {
-        val originalPath = Paths.get(result.getClientFileMetadata.originalPath.get)
-
-        val metadataMutationInput = antivirusMetadata(fileId, originalPath)
-        val mutationVariables = AddAntivirusMetadata.Variables(metadataMutationInput)
-
-        sendGraphQlRequest(antivirusClient, token, mutationVariables, AddAntivirusMetadata.document)
-      })
-    })
-  }
-
-  private def antivirusMetadata(fileId: UUID, originalPath: Path): AddAntivirusMetadataInput = {
-    val result = originalPath.getFileName.toString match {
-      case eicarPattern(_) => "SUSP_Just_EICAR"
-      case virusPattern(_) => "test_virus"
-      case _ => ""
-    }
-
-    val antivirusSoftware = "fake-local-antivirus"
-    val fakeVersion = "1.0"
-    val fakeDate = Instant.now()
-
-    AddAntivirusMetadataInput(
-      fileId,
-      Some(antivirusSoftware),
-      Some(result),
-      Some(fakeVersion),
-      Some(fakeVersion),
-      Some(result),
-      fakeDate.toEpochMilli
-    )
+  override def checkFile(fileId: UUID)(implicit executionContext: ExecutionContext): Future[Any] = {
+    for {
+      token <- tokenService.token
+      originalPath <- fileService.originalFileName(fileId, token)
+      metadata = FakeAntivirusMetadata.generate(originalPath)
+      result <- fileService.saveAntivirusResult(metadata, fileId, token)
+    } yield result
   }
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
@@ -1,0 +1,26 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
+import java.util.UUID
+
+import graphql.codegen.AddFileMetadata.addFileMetadata
+import graphql.codegen.types.AddFileMetadataInput
+import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ChecksumCheck(
+                     tokenService: TokenService,
+                     addMetadataClient: GraphQLClient[addFileMetadata.Data, addFileMetadata.Variables]
+                   )(implicit val executionContext: ExecutionContext) extends FileCheck {
+  override def checkFileId(fileId: UUID): Future[Any] = {
+    tokenService.token.flatMap(token => {
+      val checksum = "fake-checksum"
+      val addMetadataInput = AddFileMetadataInput("SHA256ServerSideChecksum", fileId, checksum)
+      // TODO: Log GraphQL error
+      addMetadataClient.getResult(token, addFileMetadata.document, Some(addFileMetadata.Variables(addMetadataInput)))
+    }).andThen(r => {
+      println("Saved checksum")
+      println(r)
+    })
+  }
+}

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
@@ -1,48 +1,26 @@
 package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
 
-import java.nio.file.{Path, Paths}
 import java.util.UUID
 
-import graphql.codegen.AddFileMetadata.addFileMetadata
-import graphql.codegen.GetOriginalPath.getOriginalPath
-import graphql.codegen.types.AddFileMetadataInput
-import uk.gov.nationalarchives.tdr.GraphQLClient
-import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.GraphQl.sendGraphQlRequest
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.FileService
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata.FakeChecksum
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ChecksumCheck(
                      tokenService: TokenService,
-                     getDocumentClient: GraphQLClient[getOriginalPath.Data, getOriginalPath.Variables],
-                     addMetadataClient: GraphQLClient[addFileMetadata.Data, addFileMetadata.Variables]
+                     fileService: FileService
                    )(implicit val executionContext: ExecutionContext) extends FileCheck {
 
-  private val customChecksumPattern = "test-checksum-(\\w*)(?:\\.\\w+)".r
-  private val defaultChecksum = "fake-checksum"
+  override def name: String = "checksum"
 
-  override def checkName: String = "checksum"
-
-  override def checkFileId(fileId: UUID): Future[Any] = {
-    tokenService.token.flatMap(token => {
-      val queryVariables = getOriginalPath.Variables(fileId)
-
-      sendGraphQlRequest(getDocumentClient, token, queryVariables, getOriginalPath.document).map(result => {
-        val originalPath = Paths.get(result.getClientFileMetadata.originalPath.get)
-
-        val checksum = generateChecksum(originalPath)
-        val addMetadataInput = AddFileMetadataInput("SHA256ServerSideChecksum", fileId, checksum)
-        val mutationVariables = addFileMetadata.Variables(addMetadataInput)
-
-        sendGraphQlRequest(addMetadataClient, token, mutationVariables, addFileMetadata.document)
-      })
-    })
-  }
-
-  private def generateChecksum(originalPath: Path): String = {
-    originalPath.getFileName.toString match {
-      case customChecksumPattern(customChecksum) => customChecksum
-      case _ => defaultChecksum
-    }
+  override def checkFile(fileId: UUID)(implicit executionContext: ExecutionContext): Future[Any] = {
+    for {
+      token <- tokenService.token
+      originalPath <- fileService.originalFileName(fileId, token)
+      checksum = FakeChecksum.generate(originalPath)
+      result <- fileService.saveChecksum(checksum, fileId, token)
+    } yield result
   }
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
@@ -1,8 +1,10 @@
 package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
 
+import java.nio.file.{Path, Paths}
 import java.util.UUID
 
 import graphql.codegen.AddFileMetadata.addFileMetadata
+import graphql.codegen.GetOriginalPath.getOriginalPath
 import graphql.codegen.types.AddFileMetadataInput
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.GraphQl.sendGraphQlRequest
@@ -12,18 +14,35 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ChecksumCheck(
                      tokenService: TokenService,
+                     getDocumentClient: GraphQLClient[getOriginalPath.Data, getOriginalPath.Variables],
                      addMetadataClient: GraphQLClient[addFileMetadata.Data, addFileMetadata.Variables]
                    )(implicit val executionContext: ExecutionContext) extends FileCheck {
+
+  private val customChecksumPattern = "test-checksum-(\\w*)(?:\\.\\w+)".r
+  private val defaultChecksum = "fake-checksum"
 
   override def checkName: String = "checksum"
 
   override def checkFileId(fileId: UUID): Future[Any] = {
     tokenService.token.flatMap(token => {
-      val checksum = "fake-checksum"
-      val addMetadataInput = AddFileMetadataInput("SHA256ServerSideChecksum", fileId, checksum)
-      val mutationVariables = addFileMetadata.Variables(addMetadataInput)
+      val queryVariables = getOriginalPath.Variables(fileId)
 
-      sendGraphQlRequest(addMetadataClient, token, mutationVariables, addFileMetadata.document)
+      sendGraphQlRequest(getDocumentClient, token, queryVariables, getOriginalPath.document).map(result => {
+        val originalPath = Paths.get(result.getClientFileMetadata.originalPath.get)
+
+        val checksum = generateChecksum(originalPath)
+        val addMetadataInput = AddFileMetadataInput("SHA256ServerSideChecksum", fileId, checksum)
+        val mutationVariables = addFileMetadata.Variables(addMetadataInput)
+
+        sendGraphQlRequest(addMetadataClient, token, mutationVariables, addFileMetadata.document)
+      })
     })
+  }
+
+  private def generateChecksum(originalPath: Path): String = {
+    originalPath.getFileName.toString match {
+      case customChecksumPattern(customChecksum) => customChecksum
+      case _ => defaultChecksum
+    }
   }
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/ChecksumCheck.scala
@@ -1,9 +1,11 @@
 package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
+
 import java.util.UUID
 
 import graphql.codegen.AddFileMetadata.addFileMetadata
 import graphql.codegen.types.AddFileMetadataInput
 import uk.gov.nationalarchives.tdr.GraphQLClient
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.GraphQl.sendGraphQlRequest
 import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -12,15 +14,16 @@ class ChecksumCheck(
                      tokenService: TokenService,
                      addMetadataClient: GraphQLClient[addFileMetadata.Data, addFileMetadata.Variables]
                    )(implicit val executionContext: ExecutionContext) extends FileCheck {
+
+  override def checkName: String = "checksum"
+
   override def checkFileId(fileId: UUID): Future[Any] = {
     tokenService.token.flatMap(token => {
       val checksum = "fake-checksum"
       val addMetadataInput = AddFileMetadataInput("SHA256ServerSideChecksum", fileId, checksum)
-      // TODO: Log GraphQL error
-      addMetadataClient.getResult(token, addFileMetadata.document, Some(addFileMetadata.Variables(addMetadataInput)))
-    }).andThen(r => {
-      println("Saved checksum")
-      println(r)
+      val mutationVariables = addFileMetadata.Variables(addMetadataInput)
+
+      sendGraphQlRequest(addMetadataClient, token, mutationVariables, addFileMetadata.document)
     })
   }
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileCheck.scala
@@ -17,6 +17,7 @@ trait FileCheck {
       case Success(fileId) => {
         // Log any errors returned by the file check, then ignore them to allow the watcher to keep running
         checkFileId(fileId).recover(error => {
+          // TODO: Make error message generic
           println(s"Error saving antivirus result for path '$path'", error)
         })
       }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileCheck.scala
@@ -12,16 +12,17 @@ trait FileCheck {
 
   def checkFileId(fileId: UUID): Future[Any]
 
+  def checkName: String
+
   def checkPath(path: Path)(implicit executionContext: ExecutionContext): Unit = {
     extractFileId(path) match {
       case Success(fileId) => {
         // Log any errors returned by the file check, then ignore them to allow the watcher to keep running
         checkFileId(fileId).recover(error => {
-          // TODO: Make error message generic
-          println(s"Error saving antivirus result for path '$path'", error)
+          println(s"Error running $checkName check for file with path '$path' and ID '$fileId'", error)
         })
       }
-      case Failure(e: IllegalArgumentException) =>
+      case Failure(_: IllegalArgumentException) =>
         println(s"Filename at path '$path' does not end in a UUID, so skipping file checks")
       case Failure(e) =>
         println(s"Error extracting file ID from path '$path'", e)

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileCheck.scala
@@ -1,43 +1,11 @@
 package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
 
-import java.nio.file.Path
 import java.util.UUID
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
 
 trait FileCheck {
+  def name: String
 
-  private val UuidLength = 36
-
-  def checkFileId(fileId: UUID): Future[Any]
-
-  def checkName: String
-
-  def checkPath(path: Path)(implicit executionContext: ExecutionContext): Unit = {
-    extractFileId(path) match {
-      case Success(fileId) => {
-        // Log any errors returned by the file check, then ignore them to allow the watcher to keep running
-        checkFileId(fileId).recover(error => {
-          println(s"Error running $checkName check for file with path '$path' and ID '$fileId'", error)
-        })
-      }
-      case Failure(_: IllegalArgumentException) =>
-        println(s"Filename at path '$path' does not end in a UUID, so skipping file checks")
-      case Failure(e) =>
-        println(s"Error extracting file ID from path '$path'", e)
-    }
-  }
-
-  private def extractFileId(path: Path): Try[UUID] = {
-    val fileName = path.getFileName.toString
-    if (fileName.length < UuidLength) {
-      return Failure(new IllegalArgumentException(s"Path '$path' is too short to contain a valid UUID"))
-    }
-
-    // S3Ninja does not store S3 folders as filesystem folders. Instead it puts underscores between the folder
-    // name and the filename, so we have to extract the last 36 digits of the filename to get the filename
-    // that would have been saved to S3.
-    Try(UUID.fromString(path.getFileName.toString.takeRight(UuidLength)))
-  }
+  def checkFile(fileId: UUID)(implicit executionContext: ExecutionContext): Future[Any]
 }

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeMetadata.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeMetadata.scala
@@ -1,0 +1,37 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata
+
+import java.nio.file.Path
+
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.AntivirusMetadata
+
+object FakeAntivirusMetadata {
+
+  private val eicarPattern = "(eicar).*".r
+  private val virusPattern = "(test-virus).*".r
+
+  def generate(originalFileName: Path): AntivirusMetadata = {
+    val result = originalFileName.toString match {
+      case eicarPattern(_) => "SUSP_Just_EICAR"
+      case virusPattern(_) => "test_virus"
+      case _ => ""
+    }
+
+    val antivirusSoftware = "fake-local-antivirus"
+    val fakeVersion = "1.0"
+
+    AntivirusMetadata(antivirusSoftware, result, fakeVersion)
+  }
+}
+
+object FakeChecksum {
+
+  private val customChecksumPattern = "test-checksum-(\\w*)(?:\\.\\w+)".r
+  private val defaultChecksum = "fake-checksum"
+
+  def generate(originalFileName: Path): String = {
+    originalFileName.toString match {
+      case customChecksumPattern(customChecksum) => customChecksum
+      case _ => defaultChecksum
+    }
+  }
+}


### PR DESCRIPTION
Add a new local check which generates a checksum based on the name of the file uploaded.

By default, the generated checksum is `fake-checksum`. If you upload a file whose name starts with "test-checksum-", the checksum saved will be whatever follows the "test-checksum-" prefix (ignoring the file extension).

This should help us work on the error path pages, because it will let us generate local cases which deliberately pass or fail the checksum checks.

We may have to modify this code soon, since we've talked about doing the checksum comparison at check time rather than when the user views the result. But it will be easier to update this local dev project once we've decided how to handle checksum checks in the AWS environments.