### PR TITLE
Add fake file format check

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,12 @@ Or run the `FakeBackendChecker` object from IntelliJ.
 
 Fake file checks generate their results based on the filenames
 
-| Filename pattern | Examples                                     | Antivirus result       | Checksum result                                       |
-| ---------------- | -------------------------------------------- | ---------------------- | ----------------------------------------------------- |
-| *                | example.txt, stuff.doc                       | Success (empty string) | `fake-checksum`                                       |
-| eicar*           | eicar, eicar123.exe                          | `SUSP_Just_EICAR`      | `fake-checksum`                                       |
-| test-virus*      | test-virus, test-virus.txt                   | `test_virus`           | `fake-checksum`                                       |
-| test-checksum-*  | test-checksum-abcde, test-checksum-abcde.doc | Success (empty string) | `abcde` (or whatever was appended to `test-checksum-` |
+| Filename pattern | Examples                                     | Antivirus result       | Checksum result                                       | File format result |
+| ---------------- | -------------------------------------------- | ---------------------- | ----------------------------------------------------- | ------------------ |
+| *                | example.txt, stuff.doc                       | Success (empty string) | `fake-checksum`                                       | `x-fmt/111`        |
+| eicar*           | eicar, eicar123.exe                          | `SUSP_Just_EICAR`      | `fake-checksum`                                       | `x-fmt/111`        |
+| test-virus*      | test-virus, test-virus.txt                   | `test_virus`           | `fake-checksum`                                       | `x-fmt/111`        |
+| test-checksum-*  | test-checksum-abcde, test-checksum-abcde.doc | Success (empty string) | `abcde` (or whatever was appended to `test-checksum-` | `x-fmt/111`        |
+| test-checksum-*  | test-checksum-abcde, test-checksum-abcde.doc | Success (empty string) | `abcde` (or whatever was appended to `test-checksum-` | `x-fmt/111`        |
+| test-fmt-*       | test-fmt-123, test-fmt-123.txt               | Success (empty string) | `fake-checksum`                                       | `fmt/123`          |
+| test-x-fmt-*     | test-x-fmt-456, test-x-fmt-456.txt           | Success (empty string) | `fake-checksum`                                       | `x-fmt/123`        |

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileFormatCheck.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/FileFormatCheck.scala
@@ -1,0 +1,26 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks
+
+import java.util.UUID
+
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.FileService
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.auth.TokenService
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata.{FakeAntivirusMetadata, FakeFileFormat}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FileFormatCheck(
+                       tokenService: TokenService,
+                       fileService: FileService
+                     )(implicit val executionContext: ExecutionContext) extends FileCheck {
+
+  override def name: String = "file format"
+
+  override def checkFile(fileId: UUID)(implicit executionContext: ExecutionContext): Future[Any] = {
+    for {
+      token <- tokenService.token
+      originalPath <- fileService.originalFileName(fileId, token)
+      metadata = FakeFileFormat.generate(originalPath)
+      result <- fileService.saveFileFormatResult(metadata, fileId, token)
+    } yield result
+  }
+}

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeMetadata.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeMetadata.scala
@@ -2,7 +2,8 @@ package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata
 
 import java.nio.file.Path
 
-import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.AntivirusMetadata
+import graphql.codegen.types.FFIDMetadataInputMatches
+import uk.gov.nationalarchives.tdr.localaws.backendchecks.api.{AntivirusMetadata, FileFormatMetadata}
 
 object FakeAntivirusMetadata {
 
@@ -33,5 +34,42 @@ object FakeChecksum {
       case customChecksumPattern(customChecksum) => customChecksum
       case _ => defaultChecksum
     }
+  }
+}
+
+object FakeFileFormat {
+
+  private val noFileFormatPattern = "(test-fmt-none)(?:.*)".r
+  private val customFileFormatPattern = "test-fmt-(\\d+)(?:.*)".r
+  private val customFileExperimentalFormatPattern = "test-x-fmt-(\\d+)(?:.*)".r
+  private val textFilePronomId = "x-fmt/111"
+
+  def generate(originalFileName: Path): FileFormatMetadata = {
+    val extension = originalFileName.toString.split("\\.") match {
+      case parts if parts.size == 1 => None
+      case parts => Some(parts.last)
+    }
+
+    val pronomId = originalFileName.toString match {
+      case noFileFormatPattern(_) => None
+      case customFileFormatPattern(pronomId) => Some(s"fmt/$pronomId")
+      case customFileExperimentalFormatPattern(pronomId) => Some(s"x-fmt/$pronomId")
+      case _ => Some(textFilePronomId)
+    }
+
+    val formatMatch = FFIDMetadataInputMatches(
+      extension,
+      "fake-file-format-identification-basis",
+      pronomId
+    )
+
+    FileFormatMetadata(
+      "fake-file-format-software",
+      "fake-file-format-software-version",
+      "fake-binary-signature-file-version",
+      "fake-container-signature-file-version",
+      "fake-file-format-match-method",
+      List(formatMatch)
+    )
   }
 }


### PR DESCRIPTION
Use the Pronom ID for text files, `x-fmt/111`, by default.

This does not support more complicated cases like multiple matches yet. We can extend this functionality if we need it.