### PR TITLE
Add unit tests for metadata generation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,53 @@
+library("tdr-jenkinslib")
+
+def repo = "tdr-local-aws"
+
+pipeline {
+  agent {
+    label "master"
+  }
+
+  stages {
+    stage("Report build start") {
+      steps {
+        script {
+          tdr.reportStartOfBuildToGitHub(repo)
+        }
+      }
+    }
+    stage("Checkout") {
+      steps {
+        checkout scm
+      }
+    }
+    stage("Run git secrets") {
+      steps {
+        script {
+          tdr.runGitSecrets(repo)
+        }
+      }
+    }
+    stage('Test') {
+      agent {
+        ecs {
+          inheritFrom 'transfer-frontend'
+        }
+      }
+      steps {
+        sh 'sbt -no-colors test'
+      }
+    }
+  }
+  post {
+    failure {
+      script {
+        tdr.reportFailedBuildToGitHub(repo)
+      }
+    }
+    success {
+      script {
+        tdr.reportSuccessfulBuildToGitHub(repo)
+      }
+    }
+  }
+}

--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeMetadata.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeMetadata.scala
@@ -26,7 +26,7 @@ object FakeAntivirusMetadata {
 
 object FakeChecksum {
 
-  private val customChecksumPattern = "test-checksum-(\\w*)(?:\\.\\w+)".r
+  private val customChecksumPattern = "test-checksum-(\\w*)(?:\\.\\w+)?".r
   private val defaultChecksum = "fake-checksum"
 
   def generate(originalFileName: Path): String = {

--- a/backend-checks/src/test/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeAntivirusMetadataTest.scala
+++ b/backend-checks/src/test/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeAntivirusMetadataTest.scala
@@ -1,0 +1,29 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata
+
+import java.nio.file.Paths
+
+import org.scalatest.matchers.should
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.propspec.AnyPropSpec
+
+class FakeAntivirusMetadataTest extends AnyPropSpec with TableDrivenPropertyChecks with should.Matchers {
+
+  case class AntivirusExample(fileName: String, expectedAntivirusResult: String)
+  val examples = Table(
+    "Antivirus metadata examples",
+    AntivirusExample("some file name.txt", ""),
+    AntivirusExample("something-eicar", ""),
+    AntivirusExample("eicar", "SUSP_Just_EICAR"),
+    AntivirusExample("eicar.txt", "SUSP_Just_EICAR"),
+    AntivirusExample("eicar-some-suffix.exe", "SUSP_Just_EICAR"),
+    AntivirusExample("test-virus", "test_virus"),
+    AntivirusExample("test-virus.jpg", "test_virus"),
+    AntivirusExample("test-virus-some-suffix.exe", "test_virus"),
+  )
+
+  property("the antivirus result is based on the file name") {
+    forAll(examples) { example =>
+      FakeAntivirusMetadata.generate(Paths.get(example.fileName)).result should equal(example.expectedAntivirusResult)
+    }
+  }
+}

--- a/backend-checks/src/test/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeChecksumTest.scala
+++ b/backend-checks/src/test/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeChecksumTest.scala
@@ -1,0 +1,31 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata
+
+import java.nio.file.Paths
+
+import org.scalatest.matchers.should
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.propspec.AnyPropSpec
+
+class FakeChecksumTest extends AnyPropSpec with TableDrivenPropertyChecks with should.Matchers {
+
+  case class ChecksumExample(fileName: String, expectedChecksum: String)
+  val examples = Table(
+    "Checksum metadata examples",
+    ChecksumExample("some file name.txt", "fake-checksum"),
+    ChecksumExample("another-file-name", "fake-checksum"),
+    ChecksumExample("not-a-test-checksum-abc.pdf", "fake-checksum"),
+    ChecksumExample("test-checksum", "fake-checksum"),
+    ChecksumExample("test-checksum-abcd", "abcd"),
+    ChecksumExample("test-checksum-EFGH.pdf", "EFGH"),
+    ChecksumExample(
+      "test-checksum-52b4ca01189d4e25b6f74010492f43b4be2e27c3c54286a2aed20c856b70f954.docx",
+      "52b4ca01189d4e25b6f74010492f43b4be2e27c3c54286a2aed20c856b70f954"
+    ),
+  )
+
+  property("the generated checksum is based on the file name") {
+    forAll(examples) { example =>
+      FakeChecksum.generate(Paths.get(example.fileName)) should equal(example.expectedChecksum)
+    }
+  }
+}

--- a/backend-checks/src/test/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeFileFormatTest.scala
+++ b/backend-checks/src/test/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/checks/metadata/FakeFileFormatTest.scala
@@ -1,0 +1,42 @@
+package uk.gov.nationalarchives.tdr.localaws.backendchecks.checks.metadata
+
+import java.nio.file.Paths
+
+import org.scalatest.matchers.should
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.propspec.AnyPropSpec
+
+class FakeFileFormatTest extends AnyPropSpec with TableDrivenPropertyChecks with should.Matchers {
+
+  case class FileFormatExample(
+                                fileName: String,
+                                expectedFileFormatId: Option[String],
+                                expectedExtension: Option[String]
+                              )
+  val defaultFileFormat = "x-fmt/111"
+  val examples = Table(
+    "File format metadata examples",
+    FileFormatExample("some file name", Some(defaultFileFormat), None),
+    FileFormatExample("some file name.txt", Some(defaultFileFormat), Some("txt")),
+    FileFormatExample("another-file.pdf", Some(defaultFileFormat), Some("pdf")),
+    FileFormatExample("test-fmt", Some(defaultFileFormat), None),
+    FileFormatExample("test-fmt-none", None, None),
+    FileFormatExample("test-fmt-none.exe", None, Some("exe")),
+    FileFormatExample("test-fmt-abc", Some(defaultFileFormat), None),
+    FileFormatExample("test-fmt-123", Some("fmt/123"), None),
+    FileFormatExample("test-fmt-456789.pdf", Some("fmt/456789"), Some("pdf")),
+    FileFormatExample("test-x-fmt", Some(defaultFileFormat), None),
+    FileFormatExample("test-x-fmt-def", Some(defaultFileFormat), None),
+    FileFormatExample("test-x-fmt-012", Some("x-fmt/012"), None),
+    FileFormatExample("test-x-fmt-3.csv", Some("x-fmt/3"), Some("csv")),
+  )
+
+  property("the file format result is based on the file name") {
+    forAll(examples) { example =>
+      val metadata = FakeFileFormat.generate(Paths.get(example.fileName))
+      metadata.matches should have size 1
+      metadata.matches(0).extension should equal(example.expectedExtension)
+      metadata.matches(0).puid should equal(example.expectedFileFormatId)
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ lazy val backendChecks = (project in file("backend-checks"))
       "com.typesafe" % "config" % "1.4.0",
       "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.18",
       "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.13",
-      "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.55"
+      "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.55",
+      "org.scalatest" %% "scalatest" % "3.1.2" % Test
     )
   )


### PR DESCRIPTION
I've added some tests for the code which converts file names to fake metadata. The main reason is to give people the confidence to add new rules without breaking the old ones.