### PR TITLE
Update tdr-graphql-client dependency

### DIFF
--- a/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/api/GraphQl.scala
+++ b/backend-checks/src/main/scala/uk/gov/nationalarchives/tdr/localaws/backendchecks/api/GraphQl.scala
@@ -2,11 +2,15 @@ package uk.gov.nationalarchives.tdr.localaws.backendchecks.api
 
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import sangria.ast.Document
+import sttp.client.{HttpURLConnectionBackend, Identity, NothingT, SttpBackend}
 import uk.gov.nationalarchives.tdr.GraphQLClient
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object GraphQl {
+
+  implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
+
   def sendGraphQlRequest[Data, Variables](
                                            client: GraphQLClient[Data, Variables],
                                            token: BearerAccessToken,

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val backendChecks = (project in file("backend-checks"))
     libraryDependencies ++= Seq(
       "com.typesafe" % "config" % "1.4.0",
       "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.18",
-      "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.13",
+      "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.15",
       "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.55",
       "org.scalatest" %% "scalatest" % "3.1.2" % Test
     )


### PR DESCRIPTION
Specify an HTTP backend to send HTTP requests to the API, now that this is required by the GraphQL client library.