### PR TITLE
Pass current commit SHA when reporting build status to GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     stage("Report build start") {
       steps {
         script {
-          tdr.reportStartOfBuildToGitHub(repo)
+          tdr.reportStartOfBuildToGitHub(repo, env.GIT_COMMIT)
         }
       }
     }
@@ -41,12 +41,12 @@ pipeline {
   post {
     failure {
       script {
-        tdr.reportFailedBuildToGitHub(repo)
+        tdr.reportFailedBuildToGitHub(repo, env.GIT_COMMIT)
       }
     }
     success {
       script {
-        tdr.reportSuccessfulBuildToGitHub(repo)
+        tdr.reportSuccessfulBuildToGitHub(repo, env.GIT_COMMIT)
       }
     }
   }


### PR DESCRIPTION
This fixes a bug in the Jenkinslib where the build status was linked to the wrong commit if extra commits were pushed to an open branch.